### PR TITLE
fix: extraclass is added to the classes of gb-select

### DIFF
--- a/projects/components-library/src/lib/components/gb-select/gb-select.component.ts
+++ b/projects/components-library/src/lib/components/gb-select/gb-select.component.ts
@@ -86,6 +86,7 @@ export class GbSelectComponent {
       if (!this.selected()) classes += " focus:border-gb-error-500 border-gb-error-500";
     }
     if (!this.selected()) classes += " text-dark-6";
+    classes += ` ${this.extraClasses()}`;
     return classes;
   });
 


### PR DESCRIPTION
# Description:
Se modifica el gb-select para adjuntarle mas clases de ser necesario

# How to test:
Crear un select y agregar clases extras

# Checklist:
My code follows the style guidelines of this project

I have performed a self-review of my code

New and existing unit tests pass locally with my changes

# Screenshots (optional):